### PR TITLE
Add service-type label

### DIFF
--- a/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
@@ -5,12 +5,14 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
 spec:
   replicas: {{ .Values.replicas }}
   template:
     metadata:
       labels:
         app: {{ .Values.name }}
+        giantswarm.io/service-type: "managed"
     spec:
       containers:
       - name: {{ .Values.name }}

--- a/helm/kubernetes-kube-state-metrics-chart/templates/rbac.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/rbac.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.name }}
   labels:
     app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.name }}
@@ -11,6 +12,9 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -19,6 +23,7 @@ metadata:
   name: {{ .Values.name }}
   labels:
     app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
 rules:
 - apiGroups:
   - ""

--- a/helm/kubernetes-kube-state-metrics-chart/templates/service-account.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/service-account.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-kube-state-metrics-chart/templates/service.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/scheme: "http"


### PR DESCRIPTION
Adds the new label. Value is `managed` because kube-state-metrics is not a core k8s component.

cc @puja108 @fgimenez @indyfree 