### PR TITLE
Add migration chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.e2e-harness
+integration/*-e2e

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -490,6 +490,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7525fbccfa6cd8a00c1bcf1678f4e4d7cf7ca13ea27acd5125eb5d4910343322"
+  inputs-digest = "d561221bfb0ecf229258d8d6b0bef150d0732bfd2f4656a69654312cfdca9bba"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v1.2.0
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kubernetes-kube-state-metrics-chart
-version: 0.1.0
+version: 0.1.1

--- a/helm/kubernetes-kube-state-metrics-chart/charts/migration/Chart.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/charts/migration/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: v1.2.0
+description: A Helm chart for migrating the Kubernetes kube-state-metrics service
+name: migration
+version: 0.1.0

--- a/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/configmap.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/configmap.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+data:
+  config.yaml: |
+    service:
+      delete:
+        resources:
+          resourceFile: "/var/run/{{ .Values.name }}/configmap/resources.json"
+      kubernetes:
+        address: ''
+        inCluster: true
+        tls:
+          caFile: ''
+          crtFile: ''
+          keyFile: ''
+  resources.json: |
+    [
+        {
+            "kind": "Service",
+            "name": "kube-state-metrics",
+            "namespace": "kube-system",
+            "matchLabels": {
+                "app": "kube-state-metrics"
+            },
+            "excludeLabels": {
+                "giantswarm.io/service-type": "managed"
+            }
+        },
+        {
+            "kind": "Deployment",
+            "name": "kube-state-metrics",
+            "namespace": "kube-system",
+            "matchLabels": {
+                "app": "kube-state-metrics"
+            },
+            "excludeLabels": {
+                "giantswarm.io/service-type": "managed"
+            }
+        },
+        {
+            "kind": "ServiceAccount",
+            "name": "kube-state-metrics",
+            "namespace": "kube-system",
+            "matchLabels": {
+                "app": "kube-state-metrics"
+            },
+            "excludeLabels": {
+                "giantswarm.io/service-type": "managed"
+            }
+        },
+        {
+            "kind": "ClusterRoleBinding",
+            "name": "kube-state-metrics",
+            "namespace": "kube-system",
+            "matchLabels": {
+                "app": "kube-state-metrics"
+            },
+            "excludeLabels": {
+                "giantswarm.io/service-type": "managed"
+            }
+        },
+        {
+            "kind": "ClusterRole",
+            "name": "kube-state-metrics",
+            "namespace": "kube-system",
+            "matchLabels": {
+                "app": "kube-state-metrics"
+            },
+            "excludeLabels": {
+                "giantswarm.io/service-type": "managed"
+            }
+        }
+    ]

--- a/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/job.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/job.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+spec:
+  template:
+    spec:
+      volumes:
+      - name: {{ .Values.name }}
+        configMap:
+          name: {{ .Values.name }}
+          items:
+          - key: config.yaml
+            path: config.yaml
+          - key: resources.json
+            path: resources.json
+      serviceAccountName: {{ .Values.name }}
+      containers:
+      - name: {{ .Values.name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        volumeMounts:
+        - name: {{ .Values.name }}
+          mountPath: /var/run/{{ .Values.name }}/configmap/
+        args:
+        - delete
+        - --config.dirs=/var/run/{{ .Values.name }}/configmap/
+        - --config.files=config
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      restartPolicy: Never
+  backoffLimit: 4

--- a/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/rbac.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/rbac.yaml
@@ -38,6 +38,10 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/rbac.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/rbac.yaml
@@ -20,8 +20,8 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - rolebindings
-  - roles
+  - clusterrolebindings
+  - clusterroles
   verbs:
   - "get"
   - "delete"

--- a/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/rbac.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.name }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+rules:
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - "get"
+  - "delete"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - "get"
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - serviceaccounts
+  verbs:
+  - "get"
+  - "delete"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.name }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/service-account.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/charts/migration/templates/service-account.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+  labels:
+    app: {{ .Values.name }}
+    giantswarm.io/service-type: "managed"

--- a/helm/kubernetes-kube-state-metrics-chart/charts/migration/values.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/charts/migration/values.yaml
@@ -1,0 +1,18 @@
+# Default values for kube-state-metrics-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+name: kube-state-metrics-migration
+namespace: kube-system
+
+image:
+  repository: quay.io/giantswarm/k8s-migrator
+  tag: latest
+
+resources:
+  limits:
+    cpu: 50m
+    memory: 75Mi
+  requests:
+    cpu: 50m
+    memory: 75Mi

--- a/integration/fixtures/resources-chart/Chart.yaml
+++ b/integration/fixtures/resources-chart/Chart.yaml
@@ -1,0 +1,3 @@
+name: resources-chart
+description: resources to be removed by migration
+version: 0.1.0

--- a/integration/fixtures/resources-chart/templates/resources.yaml
+++ b/integration/fixtures/resources-chart/templates/resources.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+  labels:
+    app: kube-state-metrics
+    kind: legacy
+spec:
+  ports:
+  - port: 10301
+  selector:
+    app: kube-state-metrics
+    kind: legacy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+  labels:
+    app: kube-state-metrics
+    kind: legacy
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+  labels:
+    app: kube-state-metrics
+    kind: legacy
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-state-metrics
+    spec:
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/giantswarm/kube-state-metrics:v1.3.1
+        args:
+          - '--port=10301'
+        resources:
+          requests:
+            cpu: 50m
+            memory: 75Mi
+      serviceAccountName: kube-state-metrics
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-state-metrics
+  labels:
+    app: kube-state-metrics
+    kind: legacy
+subjects:
+  - kind: ServiceAccount
+    name: kube-state-metrics
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: kube-state-metrics
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+  labels:
+    app: kube-state-metrics
+    kind: legacy

--- a/integration/fixtures/resources-chart/templates/resources.yaml
+++ b/integration/fixtures/resources-chart/templates/resources.yaml
@@ -31,7 +31,7 @@ metadata:
     app: kube-state-metrics
     kind: legacy
 spec:
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       labels:

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -14,6 +14,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	resourceNamespace = "kube-system"
+)
+
 var (
 	f *framework.Host
 )
@@ -110,7 +114,7 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Mask(err)
 	}
 	if len(d.Items) != 1 {
-		return microerror.Newf("unexpected number of deployments, want 1, got %d", len(ds.Items))
+		return microerror.Newf("unexpected number of deployments, want 1, got %d", len(d.Items))
 	}
 
 	r, err := c.Rbac().Roles(resourceNamespace).List(listOptions)
@@ -155,7 +159,7 @@ func checkResourcesNotPresent(labelSelector string) error {
 	}
 
 	d, err := c.Extensions().Deployments(resourceNamespace).List(listOptions)
-	if err == nil && len(ds.Items) > 0 {
+	if err == nil && len(d.Items) > 0 {
 		return microerror.New("expected error querying for deployments didn't happen")
 	}
 	if !apierrors.IsNotFound(err) {

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -122,7 +122,7 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Newf("unexpected number of deployments, want 1, got %d", len(d.Items))
 	}
 
-	r, err := c.Rbac().ClusterRoles(resourceNamespace).List(listOptions)
+	r, err := c.Rbac().ClusterRoles().List(listOptions)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -130,7 +130,7 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Newf("unexpected number of roles, want 1, got %d", len(r.Items))
 	}
 
-	rb, err := c.Rbac().ClusterRoleBindings(resourceNamespace).List(listOptions)
+	rb, err := c.Rbac().ClusterRoleBindings().List(listOptions)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -171,7 +171,7 @@ func checkResourcesNotPresent(labelSelector string) error {
 		return microerror.Mask(err)
 	}
 
-	r, err := c.Rbac().ClusterRoles(resourceNamespace).List(listOptions)
+	r, err := c.Rbac().ClusterRoles().List(listOptions)
 	if err == nil && len(r.Items) > 0 {
 		return microerror.New("expected error querying for roles didn't happen")
 	}
@@ -179,7 +179,7 @@ func checkResourcesNotPresent(labelSelector string) error {
 		return microerror.Mask(err)
 	}
 
-	rb, err := c.Rbac().ClusterRoleBindings(resourceNamespace).List(listOptions)
+	rb, err := c.Rbac().ClusterRoleBindings().List(listOptions)
 	if err == nil && len(rb.Items) > 0 {
 		return microerror.New("expected error querying for rolebindings didn't happen")
 	}

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	"github.com/giantswarm/e2e-harness/pkg/framework"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -49,9 +52,147 @@ func TestHelm(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error during installation of the chart: %v", err)
 	}
+	defer framework.HelmCmd("delete test-deploy --purge")
 
 	err = framework.HelmCmd("test --debug --cleanup test-deploy")
 	if err != nil {
 		t.Errorf("unexpected error during test of the chart: %v", err)
 	}
+}
+
+func TestMigration(t *testing.T) {
+	// Install legacy resources.
+	err := framework.HelmCmd("install /e2e/fixtures/resources-chart -n resources")
+	if err != nil {
+		t.Fatalf("could not install resources chart: %v", err)
+	}
+	defer framework.HelmCmd("delete resources --purge")
+
+	// Check legacy resources are present.
+	err = checkResourcesPresent("app=kube-state-metrics,kind=legacy")
+	if err != nil {
+		t.Fatalf("could check legacy resources present: %v", err)
+	}
+	// Check managed resources are not present.
+	err = checkResourcesNotPresent("app=kube-state-metrics,giantswarm.io/service-type=managed")
+	if err != nil {
+		t.Fatalf("could check managed resources not present: %v", err)
+	}
+
+	// Install kubernetes-kube-state-metrics-chart.
+	channel := os.Getenv("CIRCLE_SHA1")
+	err = framework.HelmCmd(fmt.Sprintf("registry install --wait quay.io/giantswarm/kubernetes-kube-state-metrics-chart:%s -n test-deploy", channel))
+	if err != nil {
+		t.Fatalf("could not install kubernetes-kube-state-metrics-chart: %v", err)
+	}
+	defer framework.HelmCmd("delete test-deploy --purge")
+
+	// Check legacy resources are not present.
+	err = checkResourcesNotPresent("app=kube-state-metrics,kind=legacy")
+	if err != nil {
+		t.Fatalf("could check legacy resources present: %v", err)
+	}
+	// Check managed resources are present.
+	err = checkResourcesPresent("app=kube-state-metrics,giantswarm.io/service-type=managed")
+	if err != nil {
+		t.Fatalf("could check managed resources not present: %v", err)
+	}
+}
+
+func checkResourcesPresent(labelSelector string) error {
+	c := f.K8sClient()
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+
+	d, err := c.Extensions().Deployments(resourceNamespace).List(listOptions)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if len(d.Items) != 1 {
+		return microerror.Newf("unexpected number of deployments, want 1, got %d", len(ds.Items))
+	}
+
+	r, err := c.Rbac().Roles(resourceNamespace).List(listOptions)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if len(r.Items) != 1 {
+		return microerror.Newf("unexpected number of roles, want 1, got %d", len(r.Items))
+	}
+
+	rb, err := c.Rbac().RoleBindings(resourceNamespace).List(listOptions)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if len(rb.Items) != 1 {
+		return microerror.Newf("unexpected number of rolebindings, want 1, got %d", len(rb.Items))
+	}
+
+	s, err := c.Core().Services(resourceNamespace).List(listOptions)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if len(s.Items) != 1 {
+		return microerror.Newf("unexpected number of services, want 1, got %d", len(s.Items))
+	}
+
+	sa, err := c.Core().ServiceAccounts(resourceNamespace).List(listOptions)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if len(sa.Items) != 1 {
+		return microerror.Newf("unexpected number of serviceaccountss, want 1, got %d", len(sa.Items))
+	}
+
+	return nil
+}
+
+func checkResourcesNotPresent(labelSelector string) error {
+	c := f.K8sClient()
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+
+	d, err := c.Extensions().Deployments(resourceNamespace).List(listOptions)
+	if err == nil && len(ds.Items) > 0 {
+		return microerror.New("expected error querying for deployments didn't happen")
+	}
+	if !apierrors.IsNotFound(err) {
+		return microerror.Mask(err)
+	}
+
+	r, err := c.Rbac().Roles(resourceNamespace).List(listOptions)
+	if err == nil && len(r.Items) > 0 {
+		return microerror.New("expected error querying for roles didn't happen")
+	}
+	if !apierrors.IsNotFound(err) {
+		return microerror.Mask(err)
+	}
+
+	rb, err := c.Rbac().RoleBindings(resourceNamespace).List(listOptions)
+	if err == nil && len(rb.Items) > 0 {
+		return microerror.New("expected error querying for rolebindings didn't happen")
+	}
+	if !apierrors.IsNotFound(err) {
+		return microerror.Mask(err)
+	}
+
+	s, err := c.Core().Services(resourceNamespace).List(listOptions)
+	if err == nil && len(s.Items) > 0 {
+		return microerror.New("expected error querying for services didn't happen")
+	}
+	if !apierrors.IsNotFound(err) {
+		return microerror.Mask(err)
+	}
+
+	sa, err := c.Core().ServiceAccounts(resourceNamespace).List(listOptions)
+	if err == nil && len(sa.Items) > 0 {
+		return microerror.New("expected error querying for serviceaccounts didn't happen")
+	}
+	if !apierrors.IsNotFound(err) {
+		return microerror.Mask(err)
+	}
+
+	return nil
 }

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -64,6 +64,11 @@ func TestHelm(t *testing.T) {
 	}
 }
 
+// TestMigration ensures that previously deployed resources are properly removed.
+// It installs a chart with the same resources as kube-state-metrics with
+// appropriate labels so that we can query for them. Then installs the
+// kube-state-metrics chart and checks that the previous resources are removed
+// and the ones for kube-state-metrics are in place.
 func TestMigration(t *testing.T) {
 	// Install legacy resources.
 	err := framework.HelmCmd("install /e2e/fixtures/resources-chart -n resources")

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -122,7 +122,7 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Newf("unexpected number of deployments, want 1, got %d", len(d.Items))
 	}
 
-	r, err := c.Rbac().Roles(resourceNamespace).List(listOptions)
+	r, err := c.Rbac().ClusterRoles(resourceNamespace).List(listOptions)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -130,7 +130,7 @@ func checkResourcesPresent(labelSelector string) error {
 		return microerror.Newf("unexpected number of roles, want 1, got %d", len(r.Items))
 	}
 
-	rb, err := c.Rbac().RoleBindings(resourceNamespace).List(listOptions)
+	rb, err := c.Rbac().ClusterRoleBindings(resourceNamespace).List(listOptions)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -171,7 +171,7 @@ func checkResourcesNotPresent(labelSelector string) error {
 		return microerror.Mask(err)
 	}
 
-	r, err := c.Rbac().Roles(resourceNamespace).List(listOptions)
+	r, err := c.Rbac().ClusterRoles(resourceNamespace).List(listOptions)
 	if err == nil && len(r.Items) > 0 {
 		return microerror.New("expected error querying for roles didn't happen")
 	}
@@ -179,7 +179,7 @@ func checkResourcesNotPresent(labelSelector string) error {
 		return microerror.Mask(err)
 	}
 
-	rb, err := c.Rbac().RoleBindings(resourceNamespace).List(listOptions)
+	rb, err := c.Rbac().ClusterRoleBindings(resourceNamespace).List(listOptions)
 	if err == nil && len(rb.Items) > 0 {
 		return microerror.New("expected error querying for rolebindings didn't happen")
 	}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1902

Adds migration chart for kube-state-metrics using the approach used in giantswarm/kubernetes-node-exporter/pull/14. Adds a migration chart that uses k8s-migrator to delete the resources.

The e2e test installs a set of resources matching those created by k8scloudconfig to test the migration. 