### PR TITLE
Use apps/v1 api version for deployment

### DIFF
--- a/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v1.2.0
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kubernetes-kube-state-metrics-chart
-version: 0.1.1
+version: 0.1.2

--- a/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.name }}

--- a/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.name }}
@@ -8,6 +8,9 @@ metadata:
     giantswarm.io/service-type: "managed"
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
   template:
     metadata:
       labels:

--- a/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ .Values.name }}

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -211,8 +211,8 @@ func checkResourcesNotPresent(labelSelector string) error {
 	return nil
 }
 
-// checkDeployment ensures that key properties of the node-exporter daemonset
-// are correct.
+// checkDeployment ensures that key properties of the kube-state-metrics
+// deployment are correct.
 func checkDeployment() error {
 	name := "kube-state-metrics"
 	expectedMatchLabels := map[string]string{

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/giantswarm/e2e-harness/pkg/framework"
@@ -228,7 +229,7 @@ func checkDeployment() error {
 	ds, err := c.Apps().Deployments(resourceNamespace).Get(name)
 	if apierrors.IsNotFound(err) {
 		return microerror.Newf("could not find daemonset: '%s' %v", name, err)
-	else if err != nil {
+	} else if err != nil {
 		return microerror.Newf("unexpected error getting daemonset: %v", err)
 	}
 

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -226,7 +226,7 @@ func checkDeployment() error {
 	expectedReplicas := 1
 
 	c := f.K8sClient()
-	ds, err := c.Apps().Deployments(resourceNamespace).Get(name)
+	ds, err := c.Apps().Deployments(resourceNamespace).Get(name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return microerror.Newf("could not find daemonset: '%s' %v", name, err)
 	} else if err != nil {
@@ -239,8 +239,8 @@ func checkDeployment() error {
 	}
 
 	// Check selector match labels.
-	if !reflect.DeepEqual(expectedLabels, ds.Spec.Selector.MatchLabels) {
-		return microerror.Newf("expected match labels: %v got: %v", expectedLabels, ds.Spec.Selector.MatchLabels)
+	if !reflect.DeepEqual(expectedMatchLabels, ds.Spec.Selector.MatchLabels) {
+		return microerror.Newf("expected match labels: %v got: %v", expectedMatchLabels, ds.Spec.Selector.MatchLabels)
 	}
 
 	// Check pod labels.
@@ -249,7 +249,7 @@ func checkDeployment() error {
 	}
 
 	// Check replica count.
-	if *ds.Spec.Replicas != expectedReplicas {
+	if *ds.Spec.Replicas != int32(expectedReplicas) {
 		return microerror.Newf("expected replicas: %d got: %d", expectedReplicas, ds.Spec.Replicas)
 	}
 

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -59,7 +59,7 @@ func TestHelm(t *testing.T) {
 	}
 	defer framework.HelmCmd("delete test-deploy --purge")
 
-	err := checkDeployment()
+	err = checkDeployment()
 	if err != nil {
 		t.Fatalf("deployment manifest is incorrect: %v", err)
 	}
@@ -249,7 +249,7 @@ func checkDeployment() error {
 	}
 
 	// Check replica count.
-	if ds.Spec.Replicas != expectedReplicas {
+	if *ds.Spec.Replicas != expectedReplicas {
 		return microerror.Newf("expected replicas: %d got: %d", expectedReplicas, ds.Spec.Replicas)
 	}
 


### PR DESCRIPTION
Towards giantswarm/k8scloudconfig/issues/291

Uses the new API version of `apps/v1`. Starting here as this deployment is being migrated to chart-operator. See https://kubernetes.io/docs/reference/workloads-18-19/

