### PR TITLE
Upgrade image to 1.3.1. Align with actual release notes

### DIFF
--- a/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.2.0
+appVersion: v1.3.1
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kubernetes-kube-state-metrics-chart
 version: 0.1.3

--- a/helm/kubernetes-kube-state-metrics-chart/values.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/values.yaml
@@ -11,7 +11,7 @@ replicas: 1
 image:
   registry: quay.io
   repository: giantswarm/kube-state-metrics
-  tag: v1.2.0
+  tag: v1.3.1
 
 resources:
   limits:


### PR DESCRIPTION
In k8scc we had 1.3.1 version and have 1.3.1 in release notes. Customer noticed that version is not correct. So updating w/o version bump.