### PR TITLE
Increases resources towards larger clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ $ helm install kubernetes-kube-state-metrics/helm/kubernetes-kube-state-metrics-
 | `image.tag`             | The image tag to pull from                      | `v1.2.0`                                |
 | `replicas`              | The number of replicas of the container         | `1`                                     |
 | `port`                  | The port of the container                       | `10301`                                 |
-| `resources`             | kube-state-metrics resource requests and limits | `cpu:50m  - memory:75Mi`                |
+| `resources`             | kube-state-metrics resource requests and limits | `cpu:100m  - memory:200Mi`              |
 | `test.image.repository` | The test image repository to pull from          | `quay.io/giantswarm/alpine-testing`     |
 | `test.image.tag`        | The test image tag to pull from                 | `0.1.0`                                 |

--- a/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v1.3.1
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kubernetes-kube-state-metrics-chart
-version: 0.1.4
+version: 0.1.5

--- a/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/deployment.yaml
@@ -24,13 +24,13 @@ spec:
         - '--port={{ .Values.port }}'
         livenessProbe:
           httpGet:
-            path: /
+            path: /healthz
             port: {{ .Values.port }}
           initialDelaySeconds: 5
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
-            path: /
+            path: /healthz
             port: {{ .Values.port }}
           initialDelaySeconds: 5
           timeoutSeconds: 5

--- a/helm/kubernetes-kube-state-metrics-chart/values.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/values.yaml
@@ -16,11 +16,11 @@ image:
 
 resources:
   limits:
-    cpu: 50m
-    memory: 75Mi
+    cpu: 100m
+    memory: 200Mi
   requests:
-    cpu: 50m
-    memory: 75Mi
+    cpu: 100m
+    memory: 200Mi
 
 test:
   image:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3712

Clusters with more resources (e.g: 200+ persistent volumes), idle at around 115Mi, which is causing some crashloops. This changeset raises the limits so we should be stable in all cases, and improves liveness and readiness probes.