### PR TITLE
Increases memory requests/limits to 300Mi

### DIFF
--- a/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v1.3.1
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kubernetes-kube-state-metrics-chart
-version: 0.1.5
+version: 0.1.6

--- a/helm/kubernetes-kube-state-metrics-chart/values.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/values.yaml
@@ -17,10 +17,10 @@ image:
 resources:
   limits:
     cpu: 100m
-    memory: 200Mi
+    memory: 300Mi
   requests:
     cpu: 100m
-    memory: 200Mi
+    memory: 300Mi
 
 test:
   image:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3909

We have a cluster that uses ~240MiB at rest (has a number of Kubernetes resources, which I think is what's pushing the memory usage up).
So, bumping to 300Mi here to have that stable.