### PR TITLE
Add deployment channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,10 @@ jobs:
 
     - run: ./architect build
 
+    - run:
+        name: Publish chart to CNR using a temporary channel for feature branch deploys
+        command: ./architect publish --pipeline=false --channel=${CIRCLE_SHA1}
+
     - persist_to_workspace:
         root: .
         paths:
@@ -87,6 +91,10 @@ jobs:
     - attach_workspace:
         at: .
 
+    - run:
+        name: Clean up temporary channel for feature branch deploys
+        command: ./architect unpublish --channels=${CIRCLE_SHA1}
+
     - run: ./architect publish --stable
 
 workflows:
@@ -98,10 +106,10 @@ workflows:
       - e2eTestBasic:
           requires:
           - build
-      
+
       - e2eTestMigration:
           requires:
-          - build 
+          - build
 
       - deploy:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
     - run:
         name: Publish chart to CNR using a temporary channel for feature branch deploys
-        command: ./architect publish --pipeline=false --channels=${CIRCLE_SHA1}
+        command: ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
 
     - persist_to_workspace:
         root: .
@@ -93,7 +93,7 @@ jobs:
 
     - run:
         name: Clean up temporary channel for feature branch deploys
-        command: ./architect unpublish --channels=${CIRCLE_SHA1}
+        command: ./architect unpublish --channels=${CIRCLE_BRANCH}
 
     - run: ./architect publish --stable
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
     - run:
         name: Publish chart to CNR using a temporary channel for feature branch deploys
-        command: ./architect publish --pipeline=false --channel=${CIRCLE_SHA1}
+        command: ./architect publish --pipeline=false --channels=${CIRCLE_SHA1}
 
     - persist_to_workspace:
         root: .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CircleCI](https://circleci.com/gh/giantswarm/kubernetes-kube-state-metrics.svg?style=svg&circle-token=1d6a6248b1d64bd698c7b68801a879ecc9e185f8)](https://circleci.com/gh/giantswarm/kubernetes-kube-state-metrics)
 
 # kube-state-metrics Helm Chart
-Helm Chart for kube-state-metrics in Guest Clusters.
+Helm Chart for kube-state-metrics in Tenant Clusters.
 
 * Installs the [kube-state-metrics agent](https://github.com/kubernetes/kube-state-metrics).
 
@@ -21,4 +21,4 @@ Provide a custom `values.yaml`:
 $ helm install kubernetes-kube-state-metrics-chart -f values.yaml
 ```
 
-Deployment to Guest Clusters is handled by [chart-operator](https://github.com/giantswarm/chart-operator).
+Deployment to Tenant Clusters is handled by [chart-operator](https://github.com/giantswarm/chart-operator).


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4012

To be able to deploy from a feature branch we need a channel, that doesn't get deleted after the e2e run.

With this change the channel will get cleaned up on merge to master (when we publish to the stable channel).