### PR TITLE
Use SHA for deployment channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     - run:
         name: Publish chart to CNR using a temporary channel for feature branch deploys
         command: |
-          ./architect publish --pipeline=false --channels=wip-${CIRCLE_BRANCH}
+          ./architect publish --pipeline=false --channels=wip-${CIRCLE_SHA1}
 
     - persist_to_workspace:
         root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ jobs:
 
     - run:
         name: Publish chart to CNR using a temporary channel for feature branch deploys
-        command: ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
+        command: |
+          ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
+          echo 'export FEATURE_BRANCH="${CIRCLE_BRANCH}"' >> $BASH_ENV
 
     - persist_to_workspace:
         root: .
@@ -93,7 +95,7 @@ jobs:
 
     - run:
         name: Clean up temporary channel for feature branch deploys
-        command: ./architect unpublish --channels=${CIRCLE_BRANCH}
+        command: ./architect unpublish --channels=${FEATURE_BRANCH}
 
     - run: ./architect publish --stable
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,7 @@ jobs:
     - run:
         name: Publish chart to CNR using a temporary channel for feature branch deploys
         command: |
-          ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
-          echo ${CIRCLE_BRANCH} > ./feature_branch
+          ./architect publish --pipeline=false --channels=wip-${CIRCLE_BRANCH}
 
     - persist_to_workspace:
         root: .
@@ -93,10 +92,6 @@ jobs:
 
     - attach_workspace:
         at: .
-
-    - run:
-        name: Clean up temporary channel for feature branch deploys
-        command: ./architect unpublish --channels=$(cat ./feature_branch)
 
     - run: ./architect publish --stable
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,18 @@ jobs:
         at: .
 
     - run:
+        name: Set branch name
+        command: |
+          ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
+          echo 'export BRANCH="$CIRCLE_BRANCH"' >> $BASH_ENV
+
+    - run:
         name: Clean up temporary channel for feature branch deploys
         command: |
-          echo $FEATURE_BRANCH
+          echo shell: $0
+          echo feature_branch: $FEATURE_BRANCH
+          echo feature_branch_braket: ${FEATURE_BRANCH}
+          echo branch: $BRANCH
           ./architect unpublish --channels=$FEATURE_BRANCH
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,8 @@ jobs:
         command: |
           ./architect unpublish --channels=$(cat ./feature_branch)
 
+    - run: ./architect publish --stable
+
 workflows:
   version: 2
   build_e2e:
@@ -122,5 +124,8 @@ workflows:
           - e2eTestMigration
 
       - publish_to_stable:
+          filters:
+            branches:
+              only: master
           requires:
-          - build
+          - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,7 @@ jobs:
 
     - run:
         name: Clean up temporary channel for feature branch deploys
-        command: |
-          ./architect unpublish --channels=$(cat ./feature_branch)
+        command: ./architect unpublish --channels=$(cat ./feature_branch)
 
     - run: ./architect publish --stable
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,6 @@ jobs:
         name: Clean up temporary channel for feature branch deploys
         command: ./architect unpublish --channels=${FEATURE_BRANCH}
 
-    - run: ./architect publish --stable
-
 workflows:
   version: 2
   build_e2e:
@@ -122,8 +120,5 @@ workflows:
           - e2eTestMigration
 
       - publish_to_stable:
-          filters:
-            branches:
-              only: master
           requires:
-          - deploy
+          - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
         root: .
         paths:
         - ./architect
-        - ./feature_branch
 
   e2eTestBasic:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
         name: Publish chart to CNR using a temporary channel for feature branch deploys
         command: |
           ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
-          echo 'export FEATURE_BRANCH="${CIRCLE_BRANCH}"' >> $BASH_ENV
+          echo 'export FEATURE_BRANCH="$CIRCLE_BRANCH"' >> $BASH_ENV
 
     - persist_to_workspace:
         root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,9 @@ jobs:
 
     - run:
         name: Clean up temporary channel for feature branch deploys
-        command: ./architect unpublish --channels=${FEATURE_BRANCH}
+        command: |
+          echo $FEATURE_BRANCH
+          ./architect unpublish --channels=$FEATURE_BRANCH
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
         name: Publish chart to CNR using a temporary channel for feature branch deploys
         command: |
           ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
-          echo $CIRCLE_BRANCH"' > ./feature_branch
+          echo ${CIRCLE_BRANCH} > ./feature_branch
 
     - persist_to_workspace:
         root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,13 @@ jobs:
         name: Publish chart to CNR using a temporary channel for feature branch deploys
         command: |
           ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
-          echo 'export FEATURE_BRANCH="$CIRCLE_BRANCH"' >> $BASH_ENV
+          echo $CIRCLE_BRANCH"' > ./feature_branch
 
     - persist_to_workspace:
         root: .
         paths:
         - ./architect
+        - ./feature_branch
 
   e2eTestBasic:
     environment:
@@ -94,19 +95,9 @@ jobs:
         at: .
 
     - run:
-        name: Set branch name
-        command: |
-          ./architect publish --pipeline=false --channels=${CIRCLE_BRANCH}
-          echo 'export BRANCH="$CIRCLE_BRANCH"' >> $BASH_ENV
-
-    - run:
         name: Clean up temporary channel for feature branch deploys
         command: |
-          echo shell: $0
-          echo feature_branch: $FEATURE_BRANCH
-          echo feature_branch_braket: ${FEATURE_BRANCH}
-          echo branch: $BRANCH
-          ./architect unpublish --channels=$FEATURE_BRANCH
+          ./architect unpublish --channels=$(cat ./feature_branch)
 
 workflows:
   version: 2


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4012, Fixes #29.

Publishing to a `wip-SHA` branch for feature branch deploys. We need the SHA after all, since chart-operator doesn't reconcile from the same channel (i.e. `branch)`

Also unpublishing on merge to master does not work since we loose the information which Commit/PR we were coming from.
Idea is to have an `architect unpublish --wip` that removes all unused channels, in a later step.