### PR TITLE
Add missing apiGroup RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,5 +18,5 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Upgraded to kube state metric [new release 1.6.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.6.0)
 - Tunned the addon resizer for bigger clusters.
 
-[0.3.1]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/42
+[0.3.1]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/43
 [0.3.0]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v1.6.0]
+## [v0.3.1]
+
+### Changed
+
+- Add `apps` api group in RBAC for deployments, daemonsets and replicas.
+
+## [v0.3.0]
 
 ### Changed
 
 - Upgraded to kube state metric [new release 1.6.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.6.0)
 - Tunned the addon resizer for bigger clusters.
 
-[1.6.0]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/40
+[0.3.1]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/42
+[0.3.0]: https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/40

--- a/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v1.6.0
 description: A Helm chart for the Kubernetes kube-state-metrics service
 name: kubernetes-kube-state-metrics-chart
-version: 0.3.0-[[ .SHA ]]
+version: 0.3.1-[[ .SHA ]]

--- a/helm/kubernetes-kube-state-metrics-chart/templates/rbac.yaml
+++ b/helm/kubernetes-kube-state-metrics-chart/templates/rbac.yaml
@@ -45,6 +45,7 @@ rules:
   - watch
 - apiGroups:
   - extensions
+  - apps
   resources:
   - daemonsets
   - deployments


### PR DESCRIPTION
Add missing apiGroup RBAC for deployments, daemonsets and replicasets after these entities have been moved to a different API group. Keep both to be compatible with old versions.