### PR TITLE
Remove project.yaml and consistently name E2E env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,28 +17,28 @@ e2eTest: &e2eTest
         name: Init cluster
         command: |
           ./e2ectl cluster create
-          cp $(./e2ectl kubeconfig path) ${TEST_DIR}/kubeconfig
+          cp $(./e2ectl kubeconfig path) ${E2E_TEST_DIR}/kubeconfig
 
     - run:
         name: Publish chart to CNR using a temporary channel for testing
-        command: ./architect publish --pipeline=false --channels=${CIRCLE_SHA1}-${TEST_NAME}
+        command: ./architect publish --pipeline=false --channels=${CIRCLE_SHA1}-${E2E_TEST_NAME}
 
     - run:
         name: Run test
         command: |
           docker run --rm --network host \
-            -v $(pwd)/${TEST_DIR}:/e2e \
+            -v $(pwd)/${E2E_TEST_DIR}:/e2e \
             -v $(pwd):/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} \
             -e E2E_KUBECONFIG=/e2e/kubeconfig \
             -e CIRCLE_SHA1=${CIRCLE_SHA1} \
             -w /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} \
-            quay.io/giantswarm/golang:1.12.6 go test -v -tags k8srequired ./${TEST_DIR}/
+            quay.io/giantswarm/golang:1.12.6 go test -v -tags k8srequired ./${E2E_TEST_DIR}/
 
     - run:
         name: Finish with cleanup, no matter if the test succeeded or not
         command: |
           ./e2ectl cluster delete
-          ./architect unpublish --channels=${CIRCLE_SHA1}-${TEST_NAME}
+          ./architect unpublish --channels=${CIRCLE_SHA1}-${E2E_TEST_NAME}
         when: always
 
 version: 2
@@ -69,8 +69,8 @@ jobs:
 
   e2eTestBasic:
     environment:
-      TEST_DIR: "integration/test/basic"
-      TEST_NAME: "basic"
+      E2E_TEST_DIR: "integration/test/basic"
+      E2E_TEST_NAME: "basic"
     <<: *e2eTest
 
   deploy:

--- a/integration/test/basic/project.yaml
+++ b/integration/test/basic/project.yaml
@@ -1,7 +1,0 @@
-version: 1
-
-test:
-  env:
-    - "KEEP_RESOURCES=${KEEP_RESOURCES}"
-    - "CIRCLE_SHA1=${CIRCLE_SHA1}"
-    - "E2E_KUBECONFIG=${E2E_KUBECONFIG}"


### PR DESCRIPTION
Towards giantswarm/giantswarm#4606

These are just couple of small consistency leftovers from prematurely merged https://github.com/giantswarm/kubernetes-kube-state-metrics/pull/50